### PR TITLE
NH-72987 - Otelcol: reduce noisy logging to CloudWatch

### DIFF
--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -25,7 +25,7 @@ processors:
 
 exporters:
   logging:
-    verbosity: detailed
+    verbosity: ${SW_APM_EXPORTER_LOG_LEVEL}
   otlp:
     endpoint: "https://otel.collector.${SW_APM_DATA_CENTER}.cloud.solarwinds.com:443"
     headers:

--- a/collector/main.go
+++ b/collector/main.go
@@ -56,7 +56,7 @@ func main() {
 }
 
 func initLogger() *zap.Logger {
-	lvl := zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	lvl := zap.NewAtomicLevelAt(zapcore.WarnLevel)
 
 	envLvl := os.Getenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")
 	userLvl, err := zap.ParseAtomicLevel(envLvl)


### PR DESCRIPTION
- Changed default log level and changed verbosity to environment variable `${SW_APM_EXPORTER_LOG_LEVEL}`

[NH-72987](https://swicloud.atlassian.net/browse/NH-72987)

[NH-72987]: https://swicloud.atlassian.net/browse/NH-72987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ