### PR TITLE
Fixed the default log level always info issue

### DIFF
--- a/collector/main.go
+++ b/collector/main.go
@@ -58,10 +58,14 @@ func main() {
 func initLogger() *zap.Logger {
 	lvl := zap.NewAtomicLevelAt(zapcore.WarnLevel)
 
-	envLvl := os.Getenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")
-	userLvl, err := zap.ParseAtomicLevel(envLvl)
-	if err == nil {
-		lvl = userLvl
+	var err error
+	envLvl, ok := os.LookupEnv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")
+	if ok {
+		var userLvl zap.AtomicLevel
+		userLvl, err = zap.ParseAtomicLevel(envLvl)
+		if err == nil {
+			lvl = userLvl
+		}
 	}
 
 	l := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), os.Stdout, lvl))

--- a/collector/main_test.go
+++ b/collector/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"os"
+	"testing"
+)
+
+func TestInitLogger(t *testing.T) {
+	logger := initLogger()
+	assert.Equal(t, zapcore.WarnLevel, logger.Level())
+}
+
+func TestInitLogger_WithEnv(t *testing.T) {
+	os.Setenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL", "debug")
+	logger := initLogger()
+	assert.Equal(t, zapcore.DebugLevel, logger.Level())
+	os.Unsetenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")
+}

--- a/collector/main_test.go
+++ b/collector/main_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestInitLogger(t *testing.T) {


### PR DESCRIPTION
I think zap and opentelemetry-lambda intended to use `info` as default

`zap.ParseAtomicLevel("")` will return `info`. Which means without defining environment variable `OPENTELEMETRY_EXTENSION_LOG_LEVEL`, the level is still overwritten no matter what is set in the default atomic level. 

Now we check the existence of the variable and parse it when necessary.