### PR TITLE
NH-73899 Otelcol: set a custom user agent header

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -90,7 +90,7 @@ func (c *Collector) Start(ctx context.Context) error {
 	params := otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{
 			Command:     "otelcol-lambda",
-			Description: "Lambda Collector",
+			Description: "SolarWinds Observability (SWO) distribution of Lambda Collector",
 			Version:     c.version,
 		},
 		ConfigProvider: c.configProvider,


### PR DESCRIPTION
- Updated the description of the collector so as to modify the user agent in otlp exporter.

`SolarWinds Observability (SWO) distribution of Lambda Collector/${version} (${runtime.GOOS}/${runtime.GOARCH})`

e.g. For this otel collector version, we are using v0.91.0 from upstream.
`SolarWinds Observability (SWO) distribution of Lambda Collector/v0.91.0 (${runtime.GOOS}/${runtime.GOARCH})`

[NH-73899](https://swicloud.atlassian.net/browse/NH-73899)

[NH-73899]: https://swicloud.atlassian.net/browse/NH-73899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ