### PR TITLE
NH-72987 - Added back Logging exporter to pipeline in config.yaml

### DIFF
--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -37,11 +37,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [resource,resourcedetection,decouple]
-      exporters: [otlp]
+      exporters: [otlp,logging]
     metrics:
       receivers: [otlp]
       processors: [resource,resourcedetection,decouple]
-      exporters: [otlp]
+      exporters: [otlp,logging]
   telemetry:
     metrics:
       address: localhost:8888


### PR DESCRIPTION
Added back logging exporter to pipeline in config.yaml. The log will be controlled by environment variable `OPENTELEMETRY_EXTENSION_LOG_LEVEL`

Need to add `OPENTELEMETRY_EXTENSION_LOG_LEVEL=info` or upper level to enable the log from logging exporter. 

[NH-72987](https://swicloud.atlassian.net/browse/NH-72987)

[NH-72987]: https://swicloud.atlassian.net/browse/NH-72987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ