### PR TITLE
NH-74565 - Otelcol: update lambda layer arch value from amd64 to x86_64

### DIFF
--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         architecture:
-          - amd64
+          - x86_64
           - arm64
     outputs:
       COLLECTOR_VERSION: ${{ steps.save-collector-version.outputs.COLLECTOR_VERSION }}
@@ -26,13 +26,13 @@ jobs:
         with:
           go-version: '^1.20.8'
       - name: build
-        run: make -C collector package GOARCH=${{ matrix.architecture }}
+        run: make -C collector package GOARCH=${{ matrix.architecture == 'x86_64' && 'amd64' || 'arm64' }}
       - uses: actions/upload-artifact@v4
         with:
           name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
           path: ${{ github.workspace }}/collector/build/opentelemetry-collector-layer-${{ matrix.architecture }}.zip
       - name: Save Collector Version
-        if: ${{ matrix.architecture == 'amd64' }}
+        if: ${{ matrix.architecture == 'x86_64' }}
         id: save-collector-version
         shell: bash
         # `./collector -v` output is in the form `v0.75.0`
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         architecture:
-          - amd64
+          - x86_64
           - arm64
         aws_region:
           - ap-northeast-1

--- a/.github/workflows/release-layer-staging-collector.yml
+++ b/.github/workflows/release-layer-staging-collector.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         architecture:
-          - amd64
+          - x86_64
           - arm64
     outputs:
       COLLECTOR_VERSION: ${{ steps.save-collector-version.outputs.COLLECTOR_VERSION }}
@@ -26,13 +26,13 @@ jobs:
         with:
           go-version: '^1.20.8'
       - name: build
-        run: make -C collector package GOARCH=${{ matrix.architecture }}
+        run: make -C collector package GOARCH=${{ matrix.architecture == 'x86_64' && 'amd64' || 'arm64' }}
       - uses: actions/upload-artifact@v4
         with:
           name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
           path: ${{ github.workspace }}/collector/build/opentelemetry-collector-layer-${{ matrix.architecture }}.zip
       - name: Save Collector Version
-        if: ${{ matrix.architecture == 'amd64' }}
+        if: ${{ matrix.architecture == 'x86_64' }}
         id: save-collector-version
         shell: bash
         # `./collector -v` output is in the form `v0.75.0`
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         architecture:
-          - amd64
+          - x86_64
           - arm64
         aws_region:
           - ap-northeast-1


### PR DESCRIPTION
Renamed amd64 to x86_64 for standardization in Solarwinds.

[NH-74565](https://swicloud.atlassian.net/browse/NH-74565)

[NH-74565]: https://swicloud.atlassian.net/browse/NH-74565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ