### PR TITLE
NH-76996 - Change log level to debug and keep parsing log event

### DIFF
--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -218,8 +218,8 @@ func (r *telemetryAPIReceiver) createLogs(slice []telemetryapi.Event) (plog.Logs
 					if t, err := parseTimestamp(timestamp); err == nil {
 						logRecord.SetTimestamp(pcommon.NewTimestampFromTime(t))
 					} else {
-						r.logger.Error("error parsing time", zap.Error(err))
-						return plog.Logs{}, err
+						// Just print a debug message
+						r.logger.Debug("error parsing time", zap.Error(err))
 					}
 				}
 				if level, ok := record["level"].(string); ok {


### PR DESCRIPTION
With regards to https://github.com/solarwinds/opentelemetry-lambda/pull/32#issuecomment-2218820371

- Changed log level to debug and keep parsing log event

[NH-76996](https://swicloud.atlassian.net/browse/NH-76996)

[NH-76996]: https://swicloud.atlassian.net/browse/NH-76996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ