### PR TITLE
NH-76996 - Fixed WARNING from python logging library

### DIFF
--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -223,7 +223,7 @@ func (r *telemetryAPIReceiver) createLogs(slice []telemetryapi.Event) (plog.Logs
 					}
 				}
 				if level, ok := record["level"].(string); ok {
-					logRecord.SetSeverityNumber(severityTextToNumber(level))
+					logRecord.SetSeverityNumber(severityTextToNumber(strings.ToUpper(level)))
 					logRecord.SetSeverityText(logRecord.SeverityNumber().String())
 				}
 				if requestId, ok := record["requestId"].(string); ok {
@@ -275,6 +275,7 @@ func severityTextToNumber(severityText string) plog.SeverityNumber {
 		"FATAL4":   plog.SeverityNumberFatal4,
 		"CRITICAL": plog.SeverityNumberFatal,
 		"ALL":      plog.SeverityNumberTrace,
+		"WARNING":  plog.SeverityNumberWarn,
 	}
 	if ans, ok := mapping[strings.ToUpper(severityText)]; ok {
 		return ans

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -457,6 +457,10 @@ func TestSeverityTextToNumber(t *testing.T) {
 			number: plog.SeverityNumberTrace,
 		},
 		{
+			level:  "WARNING",
+			number: plog.SeverityNumberWarn,
+		},
+		{
 			level:  "UNKNOWN",
 			number: plog.SeverityNumberUnspecified,
 		},


### PR DESCRIPTION
- Added `WARNING` to the mapping
- Added `ToUpper` function to the severity text in case the level is not upper case


[NH-76996](https://swicloud.atlassian.net/browse/NH-76996)

[NH-76996]: https://swicloud.atlassian.net/browse/NH-76996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ