### PR TITLE
NH-70492 Fixed platform empty log record issues

### DIFF
--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -296,16 +296,16 @@ func (r *telemetryAPIReceiver) createLogs(slice []event) (plog.Logs, error) {
 	scopeLog.Scope().SetName(scopeName)
 	for _, el := range slice {
 		r.logger.Debug(fmt.Sprintf("Event: %s", el.Type), zap.Any("event", el))
-		logRecord := scopeLog.LogRecords().AppendEmpty()
-		logRecord.Attributes().PutStr("type", el.Type)
-		if t, err := time.Parse(time.RFC3339, el.Time); err == nil {
-			logRecord.SetTimestamp(pcommon.NewTimestampFromTime(t))
-			logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-		} else {
-			r.logger.Error("error parsing time", zap.Error(err))
-			return plog.Logs{}, err
-		}
 		if el.Type == string(telemetryapi.Function) || el.Type == string(telemetryapi.Extension) {
+			logRecord := scopeLog.LogRecords().AppendEmpty()
+			logRecord.Attributes().PutStr("type", el.Type)
+			if t, err := time.Parse(time.RFC3339, el.Time); err == nil {
+				logRecord.SetTimestamp(pcommon.NewTimestampFromTime(t))
+				logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			} else {
+				r.logger.Error("error parsing time", zap.Error(err))
+				return plog.Logs{}, err
+			}
 			if record, ok := el.Record.(map[string]interface{}); ok {
 				// in JSON format https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#telemetry-api-function
 				if timestamp, ok := record["timestamp"].(string); ok {

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -532,6 +532,138 @@ func TestCreateLogs(t *testing.T) {
 			expectedSeverityNumber:    plog.SeverityNumberUnspecified,
 			expectError:               false,
 		},
+		{
+			desc: "platform.initStart anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.initStart",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.initRuntimeDone anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.initRuntimeDone",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.initReport anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.initReport",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.start anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.start",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.runtimeDone anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.runtimeDone",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.report anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.report",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.restoreStart anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.restoreStart",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.restoreRuntimeDone anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.restoreRuntimeDone",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.restoreReport anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.restoreStart",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.telemetrySubscription anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.telemetrySubscription",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
+		{
+			desc: "platform.logsDropped anything",
+			slice: []event{
+				{
+					Time:   "2022-10-12T00:03:50.000Z",
+					Type:   "platform.logsDropped",
+					Record: map[string]any{},
+				},
+			},
+			expectedLogRecords: 0,
+			expectError:        false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
## Problem
Empty log records are created when subscribing `platform` type in telemetry API receiver and has telemetry API receiver  in `logs` pipeline

## Investigation
1. From [here](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/receiver/telemetryapireceiver/receiver.go#L194-L202), log record(s) are created before checking the type of the event. Causing telemetry API receiver creates empty log record for `platform.*` events

## Solution
- Making sure the type is either `function` or `extension` before creating an log record.
- Added related unit test cases to verify the function.

This PR is to fix this problem.