### PR TITLE
NH-110814 - Enabling CodeQL on swo branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "swo" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "swo" ]
   schedule:
     - cron: '37 10 * * 2'
 


### PR DESCRIPTION
Although CodeQL doesn't really check collector golang code, need to enable to stop repo's complaint. 