### PR TITLE
NH-110814 - Removed "status: write" GITHUB_TOKEN permission from security suggestion

### DIFF
--- a/.github/workflows/release-layer-staging-collector.yml
+++ b/.github/workflows/release-layer-staging-collector.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  statuses: write
 
 jobs:
   build-layer:

--- a/.github/workflows/reversinglabs.yml
+++ b/.github/workflows/reversinglabs.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  statuses: write
 
 jobs:
   scan:


### PR DESCRIPTION
Fixing 

[Token-Permissions](https://github.com/solarwinds/opentelemetry-lambda/security/code-scanning/15)
[Token-Permissions](https://github.com/solarwinds/opentelemetry-lambda/security/code-scanning/16)


https://swicloud.atlassian.net/browse/NH-110814