### PR TITLE
NH-110814 - Added reversinglabscan to release-layer-collector.yml(prod)

### DIFF
--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -60,6 +60,18 @@ jobs:
           COLLECTOR_VERSION=$( ${{ github.workspace }}/collector/build/extensions/collector -v)
           echo "COLLECTOR_VERSION=$COLLECTOR_VERSION" >> $GITHUB_OUTPUT
 
+  scan:
+    uses: ./.github/workflows/reversinglabs.yml
+    needs: build-layer
+    strategy:
+      matrix:
+        architecture:
+          - x86_64
+          - arm64
+    with:
+      artifact-name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
+    secrets: inherit
+
   publish-layer:
     uses: ./.github/workflows/layer-publish.yml
     needs: build-layer


### PR DESCRIPTION
It is the last follow up for NH-110814 by adding reversinglab scan to release-layer-collector.yml , copied from release-layer-staging-collector.yml

[NH-110814](https://swicloud.atlassian.net/browse/NH-110814)

[NH-110814]: https://swicloud.atlassian.net/browse/NH-110814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ