### PR TITLE
NH-87870 Otel Col: Added default value for some environment variables

### DIFF
--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -1,6 +1,6 @@
 extensions:
   solarwindsapmsettings:
-    endpoint: "apm.collector.${env:SW_APM_DATA_CENTER}.cloud.solarwinds.com:443"
+    endpoint: "apm.collector.${env:SW_APM_DATA_CENTER:-na-01}.cloud.solarwinds.com:443"
     key: "${env:SW_APM_API_TOKEN}:${env:OTEL_SERVICE_NAME}"
 
 receivers:
@@ -11,7 +11,7 @@ receivers:
       http:
         endpoint: "localhost:4318"
   telemetryapi:
-    types: ${env:SW_APM_TELEMETRY_API_SUBSCRIPTION}
+    types: ${env:SW_APM_TELEMETRY_API_SUBSCRIPTION:-platform,function,extension}
 
 processors:
   batch:
@@ -37,7 +37,7 @@ exporters:
   debug:
     verbosity: detailed
   otlp:
-    endpoint: "https://otel.collector.${env:SW_APM_DATA_CENTER}.cloud.solarwinds.com:443"
+    endpoint: "https://otel.collector.${env:SW_APM_DATA_CENTER:-na-01}.cloud.solarwinds.com:443"
     headers:
       Authorization: "Bearer ${env:SW_APM_API_TOKEN}"
 


### PR DESCRIPTION
Added default value for `SW_APM_TELEMETRY_API_SUBSCRIPTION` & `SW_APM_DATA_CENTER` environment variables so that we will not see warning like
```
{
    "level": "warn",
    "ts": 1748036187.8615668,
    "caller": "envprovider@v1.32.0/provider.go:61",
    "msg": "Configuration references unset environment variable",
    "name": "SW_APM_TELEMETRY_API_SUBSCRIPTION"
}
```
https://swicloud.atlassian.net/browse/NH-87870
