### PR TITLE
Removed unavailable me-south-1 due to regional conflict and no ETA from AWS

### DIFF
--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -44,7 +44,6 @@ on:
           - eu-west-3
           - il-central-1
           - me-central-1
-          - me-south-1
           - mx-central-1
           - sa-east-1
           - us-east-1
@@ -128,7 +127,7 @@ jobs:
           fi
           aws_regions=''
           if [ ${{ github.event.inputs.aws-region }} == 'all' ]; then
-            aws_regions='["af-south-1", "ap-east-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4", "ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3", "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"]'
+            aws_regions='["af-south-1", "ap-east-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4", "ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3", "il-central-1", "me-central-1", "mx-central-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"]'
           else
             aws_regions='["${{ github.event.inputs.aws-region }}"]'
           fi

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -116,7 +116,6 @@ jobs:
           - eu-west-3
           - il-central-1
           - me-central-1
-          - me-south-1
           - mx-central-1
           - sa-east-1
           - us-east-1

--- a/.github/workflows/release-layer-staging-collector.yml
+++ b/.github/workflows/release-layer-staging-collector.yml
@@ -101,7 +101,6 @@ jobs:
           - eu-west-3
           - il-central-1
           - me-central-1
-          - me-south-1
           - mx-central-1
           - sa-east-1
           - us-east-1


### PR DESCRIPTION
This pull request updates the AWS region configuration in several GitHub Actions workflow files by removing the `me-south-1` region from the list of targeted deployment regions. This change ensures that workflows no longer attempt to deploy or release resources to the `me-south-1` region.

**AWS region configuration updates:**

* Removed `me-south-1` from the region lists in the following workflow files:
  - `.github/workflows/publish-layer-collector.yml` (`on:` and region array in jobs) [[1]](diffhunk://#diff-6289700a2842599e7bbdfd13a1a22f68ba940bfdf6b1187b8037e03da268feacL47) [[2]](diffhunk://#diff-6289700a2842599e7bbdfd13a1a22f68ba940bfdf6b1187b8037e03da268feacL131-R130)
  - `.github/workflows/release-layer-collector.yml`
  - `.github/workflows/release-layer-staging-collector.yml`